### PR TITLE
Add Vault support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /coverage
 build/
+config/secrets.json

--- a/config/kuzzlerc
+++ b/config/kuzzlerc
@@ -6,8 +6,8 @@
       "signedUrlTTL": "20min",
       "redisPrefix": "s3Plugin/uploads",
       "vault": {
-        "accessKeyIdPath": "toto.s3.accessKeyId",
-        "secretAccessKeyPath": "toto.s3.secretAccessKey"
+        "accessKeyIdPath": "foo.s3.accessKeyId",
+        "secretAccessKeyPath": "foo.s3.secretAccessKey"
       }
     }
   }

--- a/config/kuzzlerc
+++ b/config/kuzzlerc
@@ -1,0 +1,14 @@
+{
+  "plugins": {
+    "s3": {
+      "bucketName": "your-s3-bucket",
+      "region": "eu-west-3",
+      "signedUrlTTL": "20min",
+      "redisPrefix": "s3Plugin/uploads",
+      "vault": {
+        "accessKeyIdPath": "toto.s3.accessKeyId",
+        "secretAccessKeyPath": "toto.s3.secretAccessKey"
+      }
+    }
+  }
+}

--- a/config/secrets.sample.json
+++ b/config/secrets.sample.json
@@ -1,0 +1,8 @@
+{
+  "aws": {
+    "s3": {
+      "accessKeyId": "accessKeyId",
+      "secretAccessKey": "secretAccessKey"
+    }
+  }
+}

--- a/doc/essentials/installation/index.md
+++ b/doc/essentials/installation/index.md
@@ -24,10 +24,10 @@ In your `kuzzlerc` file, you can change the following configuration variable:
 
   - `bucketName`: AWS S3 bucket
   - `region`: AWS S3 region
-  - `signedUrlTTL`: TTL in [ms](https://www.npmjs.com/package/ms) format before Presigned URL expire or the uploaded file is deleted
+  - `signedUrlTTL`: TTL in [ms](https://www.npmjs.com/package/ms) format before the presigned URL expires, or before the uploaded file is deleted
   - `redisPrefix`: Redis key prefix
-  - `vault.accessKeyIdPath`: Path to AWS Access key id in Vault
-  - `vault.secretAccessKeyPath`: Path to AWS secret access key in Vault
+  - `vault.accessKeyIdPath`: Path to the AWS Access key id in the Vault
+  - `vault.secretAccessKeyPath`: Path to the AWS secret access key in the Vault
 
 ```js
 {
@@ -50,7 +50,7 @@ In your `kuzzlerc` file, you can change the following configuration variable:
 
 This plugin needs AWS S3 credentials with the `PutObject` and `DeleteObject` permissions.  
  
-Theses credentials can be set in the [Vault](/core/1/guides/essentials/secrets-vault/).  
+These credentials can be set in the [Vault](/core/1/guides/essentials/secrets-vault/).  
 
 By default the format is the following:
 ```js

--- a/doc/essentials/installation/index.md
+++ b/doc/essentials/installation/index.md
@@ -20,15 +20,14 @@ You can now restart Kuzzle and check [http://localhost:7512](http://localhost:75
 
 ## Plugin configuration
 
-You need to set your AWS access key in the environment: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.  
-Your access key must have the following rights: `PutObject` and `DeleteObject`.  
-
-Then in your `kuzzlerc` file, you can change the following configuration variable:
+In your `kuzzlerc` file, you can change the following configuration variable:
 
   - `bucketName`: AWS S3 bucket
   - `region`: AWS S3 region
-  - `signedUrlTTL`: TTL in ms before Presigned URL expire or the uploaded file is deleted
+  - `signedUrlTTL`: TTL in [ms](https://www.npmjs.com/package/ms) format before Presigned URL expire or the uploaded file is deleted
   - `redisPrefix`: Redis key prefix
+  - `vault.accessKeyIdPath`: Path to AWS Access key id in Vault
+  - `vault.secretAccessKeyPath`: Path to AWS secret access key in Vault
 
 ```js
 {
@@ -36,12 +35,42 @@ Then in your `kuzzlerc` file, you can change the following configuration variabl
     "s3": {
       "bucketName": "your-s3-bucket",
       "region": "eu-west-3",
-      "signedUrlTTL": 1200000,
-      "redisPrefix": "s3Plugin/uploads"
+      "signedUrlTTL": "20min",
+      "redisPrefix": "s3Plugin/uploads",
+      "vault": {
+        "accessKeyIdPath": "aws.s3.accessKeyId",
+        "secretAccessKeyPath": "aws.s3.secretAccessKey"
+      }
     }
   }
 }
 ```
+
+## Credentials
+
+This plugin needs AWS S3 credentials with the `PutObject` and `DeleteObject` permissions.  
+ 
+Theses credentials can be set in the [Vault](/core/1/guides/essentials/secrets-vault/).  
+
+By default the format is the following:
+```js
+{
+  "aws": {
+    "s3": {
+      "accessKeyId": "accessKeyId",
+      "secretAccessKey": "secretAccessKey"
+    }
+  }
+}
+```
+
+You can change the path of the credentials used by the plugin by changing the `vault.accessKeyIdPath` and `vault.secretAccessKeyPath` values in the configuration.  
+
+If you cannot use the Vault, it's also possible to set the AWS S3 credentials in the following environment variables:
+  - `AWS_ACCESS_KEY_ID`
+  - `AWS_SECRET_ACCESS_KEY`
+
+Environment variable have precedence over the Vault.
 
 ## AWS S3 Bucket configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,12 @@ services:
     image: kuzzleio/plugin-dev:${KUZZLE_DOCKER_TAG:-latest}
     command: /run-dev.sh
     volumes:
-      - "./run-dev.sh:/run-dev.sh"
-      - "./install-plugins.sh:/install-plugins.sh"
-      - "./pm2.json:/config/pm2.json"
-      - "..:/var/app/plugins/enabled/kuzzle-plugin-s3"
+      - "./docker/run-dev.sh:/run-dev.sh"
+      - "./docker/install-plugins.sh:/install-plugins.sh"
+      - "./docker/pm2.json:/config/pm2.json"
+      - "./config:/var/app/config"
+      - "./config/kuzzlerc:/etc/kuzzlerc"
+      - ".:/var/app/plugins/enabled/kuzzle-plugin-s3"
     cap_add:
       - SYS_PTRACE
     ulimits:
@@ -27,6 +29,7 @@ services:
       - kuzzle_services__memoryStorage__node__host=redis
       - NODE_ENV=development
       - DEBUG=kuzzle:plugins
+      - KUZZLE_VAULT_KEY=${KUZZLE_VAULT_KEY}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 

--- a/lib/S3Plugin.js
+++ b/lib/S3Plugin.js
@@ -20,6 +20,7 @@
  */
 
 const
+  ms = require('ms'),
   AWS = require('aws-sdk'),
   uuid = require('uuid/v4');
 
@@ -44,8 +45,12 @@ class S3Plugin {
     this.defaultConfig = {
       bucketName: 'your-s3-bucket',
       region: 'eu-west-3',
-      signedUrlTTL: 20 * 60 * 1000,
-      redisPrefix: 's3Plugin/uploads'
+      signedUrlTTL: '20min',
+      redisPrefix: 's3Plugin/uploads',
+      vault: {
+        accessKeyIdPath: 'aws.s3.accessKeyId',
+        secretAccessKeyPath: 'aws.s3.secretAccessKey'
+      }
     };
 
     this.hooks = {};
@@ -65,42 +70,45 @@ class S3Plugin {
 
     this.routes = [
       // Upload controller
-      { verb: 'get', url: '/upload', controller: 'upload', action: 'getUrl' },
-      { verb: 'put', url: '/upload/:fileKey', controller: 'upload', action: 'validate' },
+      {
+        verb: 'get',
+        url: '/upload',
+        controller: 'upload',
+        action: 'getUrl'
+      },
+      {
+        verb: 'put',
+        url: '/upload/:fileKey',
+        controller: 'upload',
+        action: 'validate'
+      },
       // File controller
-      { verb: 'get', url: '/files/:fileKey', controller: 'file', action: 'getUrl' },
-      { verb: 'delete', url: '/files/:fileKey', controller: 'file', action: 'delete' }
+      {
+        verb: 'get',
+        url: '/files/:fileKey',
+        controller: 'file',
+        action: 'getUrl'
+      },
+      {
+        verb: 'delete',
+        url: '/files/:fileKey',
+        controller: 'file',
+        action: 'delete'
+      }
     ];
   }
 
   init (customConfig, context) {
     this.config = { ...this.defaultConfig, ...customConfig };
+    if (typeof this.config.signedUrlTTL !== 'number') {
+      this.config.signedUrlTTL = ms(this.config.signedUrlTTL);
+    }
 
     this.context = context;
 
     this.baseFileUrl = `https://s3.${this.config.region}.amazonaws.com/${this.config.bucketName}`;
 
-    const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, NODE_ENV } = process.env;
-
-    this.unavailableMessage = 'File upload unavailable. AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not set.';
-
-    this.s3 = null;
-
-    if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
-      // Don't start Kuzzle in production if credentials are missing
-      if (NODE_ENV === 'production') {
-        throw new this.context.errors.InternalError(this.unavailableMessage);
-      }
-    } else {
-      this.s3 = new AWS.S3({
-        signatureVersion: 'v4',
-        region: this.config.region,
-        credentials: {
-          accessKeyId: AWS_ACCESS_KEY_ID,
-          secretAccessKey: AWS_SECRET_ACCESS_KEY
-        }
-      });
-    }
+    this._loadS3();
   }
 
   /**
@@ -194,7 +202,9 @@ class S3Plugin {
     const fileKey = this._stringArg(request, 'fileKey');
 
     if (!await this._fileExists(fileKey)) {
-      throw new this.context.errors.NotFoundError(`Unabled to find file "${fileKey}".`);
+      throw new this.context.errors.NotFoundError(
+        `Unabled to find file "${fileKey}".`
+      );
     }
 
     await this._deleteFile(fileKey);
@@ -210,7 +220,9 @@ class S3Plugin {
   _expireFile (fileKey) {
     const redisKey = `${this.config.redisPrefix}/${fileKey}`;
 
-    this.context.accessors.sdk.ms.set(redisKey, 'temporary', { ex: this.config.signedUrlTTL / 1000 + 60 });
+    this.context.accessors.sdk.ms.set(redisKey, 'temporary', {
+      ex: this.config.signedUrlTTL / 1000 + 60
+    });
 
     setTimeout(async () => {
       if (!await this.context.accessors.sdk.ms.get(redisKey)) {
@@ -230,7 +242,10 @@ class S3Plugin {
    * @param {string} fileKey
    */
   _deleteFile (fileKey) {
-    return this.s3.deleteObject({ Bucket: this.config.bucketName, Key: fileKey }).promise();
+    return this.s3.deleteObject({
+      Bucket: this.config.bucketName,
+      Key: fileKey
+    }).promise();
   }
 
   /**
@@ -240,7 +255,10 @@ class S3Plugin {
    */
   async _fileExists (fileKey) {
     try {
-      await this.s3.headObject({ Bucket: this.config.bucketName, Key: fileKey }).promise();
+      await this.s3.headObject({
+        Bucket: this.config.bucketName,
+        Key: fileKey
+      }).promise();
 
       return true;
     } catch (error) {
@@ -270,22 +288,59 @@ class S3Plugin {
    * @returns {string}
    */
   _stringArg(request, paramPath, defaultValue = null) {
-    const stringParam = getProperty(request.input.args, paramPath) || defaultValue;
+    const stringParam = getProperty(request.input.args, paramPath)
+      || defaultValue;
 
     if (!stringParam) {
-      throw new this.context.errors.BadRequestError(`Missing arg "${paramPath}"`);
+      throw new this.context.errors.BadRequestError(
+        `Missing arg "${paramPath}"`
+      );
     }
 
     if (typeof stringParam !== 'string') {
-      throw new this.context.errors.BadRequestError(`Invalid string arg "${paramPath}" value "${stringParam}"`);
+      throw new this.context.errors.BadRequestError(
+        `Invalid string arg "${paramPath}" value "${stringParam}"`
+      );
     }
 
     return stringParam;
   }
 
   _assertCredentials () {
-    if (!this.s3) {
+    if (! this.s3) {
       throw new this.context.errors.InternalError(this.unavailableMessage);
+    }
+  }
+
+  _loadS3 () {
+    const
+      accessKeyId = process.env.AWS_ACCESS_KEY_ID
+        || getProperty(this.context.secrets, this.config.vault.accessKeyIdPath),
+      secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
+        || getProperty(this.context.secrets, this.config.vault.secretAccessKeyPath),
+      nodeEnv = process.env.NODE_ENV;
+
+    this.unavailableMessage = `S3 service unavailable. \
+You must either set ${this.config.vault.accessKeyIdPath} and \
+${this.config.vault.secretAccessKeyPath} in the Vault \
+or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.`;
+
+    this.s3 = null;
+
+    if (!accessKeyId || !secretAccessKey) {
+      // Don't start Kuzzle in production if credentials are missing
+      if (nodeEnv === 'production') {
+        throw new this.context.errors.InternalError(this.unavailableMessage);
+      }
+    } else {
+      this.s3 = new AWS.S3({
+        signatureVersion: 'v4',
+        region: this.config.region,
+        credentials: {
+          accessKeyId: accessKeyId,
+          secretAccessKey: secretAccessKey
+        }
+      });
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3000,9 +3000,9 @@
       }
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.4",
     "aws-sdk": "^2.434.0",
+    "ms": "^2.1.2",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "semver": "^6.0.0",

--- a/test/S3Plugin.test.js
+++ b/test/S3Plugin.test.js
@@ -2,10 +2,10 @@ const
   KuzzleErrors = require('kuzzle-common-objects').errors,
   mockrequire = require('mock-require'),
   sinon = require('sinon'),
-  { 
+  {
     BadRequestError,
     NotFoundError,
-    InternalError: KuzzleInternalError 
+    InternalError: KuzzleInternalError
   } = require('kuzzle-common-objects').errors,
   should = require('should');
 
@@ -57,7 +57,7 @@ describe('S3Plugin', () => {
       bucketName: 'half-life',
       uploadDir: 'xen',
       region: 'eu-west-3',
-      signedUrlTTL: 3600 * 1000,
+      signedUrlTTL: '60min',
       redisPrefix: 's3Plugin/uploads'
     };
 
@@ -102,7 +102,7 @@ describe('S3Plugin', () => {
             filename: 'headcrab.png'
           }
         }
-      };  
+      };
     });
 
     it('returns a presigned url from aws s3', async () => {
@@ -140,7 +140,7 @@ describe('S3Plugin', () => {
             should(s3Plugin.context.accessors.sdk.ms.get).be.calledOnce();
             should(deleteObjectMock)
               .be.calledOnce()
-              .be.calledWith({ Bucket: 'half-life', Key: 'xen/0-headcrab.png' });            
+              .be.calledWith({ Bucket: 'half-life', Key: 'xen/0-headcrab.png' });
             should(s3Plugin.context.accessors.sdk.ms.del)
               .be.calledOnce()
               .be.calledWith(['s3Plugin/uploads/xen/0-headcrab.png']);
@@ -167,7 +167,7 @@ describe('S3Plugin', () => {
 
       return should(
         s3Plugin.uploadGetUrl(request)
-      ).be.rejectedWith(KuzzleInternalError);          
+      ).be.rejectedWith(KuzzleInternalError);
     });
   });
 
@@ -179,16 +179,16 @@ describe('S3Plugin', () => {
             fileKey: 'xen/0-headcrab.png'
           }
         }
-      };  
+      };
     });
 
     it('deletes the associated key in Redis', async () => {
       const response = await s3Plugin.uploadValidate(request);
-      
+
       should(s3Plugin.context.accessors.sdk.ms.del)
         .be.calledOnce()
         .be.calledWith(['s3Plugin/uploads/xen/0-headcrab.png']);
-      
+
       should(response).be.eql({
         fileKey: 'xen/0-headcrab.png',
         fileUrl: 'https://s3.eu-west-3.amazonaws.com/half-life/xen/0-headcrab.png'
@@ -212,7 +212,7 @@ describe('S3Plugin', () => {
             fileKey: 'xen/0-headcrab.png'
           }
         }
-      };  
+      };
     });
 
     it('delete the file using aws sdk', async () => {
@@ -251,7 +251,7 @@ describe('S3Plugin', () => {
 
       return should(
         s3Plugin.fileDelete(request)
-      ).be.rejectedWith(KuzzleInternalError);          
+      ).be.rejectedWith(KuzzleInternalError);
     });
   });
 
@@ -263,12 +263,12 @@ describe('S3Plugin', () => {
             fileKey: 'xen/0-headcrab.png'
           }
         }
-      };  
+      };
     });
 
     it('returns the file url', async () => {
       const response = await s3Plugin.fileGetUrl(request);
-      
+
       should(response).be.eql({
         fileUrl: 'https://s3.eu-west-3.amazonaws.com/half-life/xen/0-headcrab.png'
       });


### PR DESCRIPTION
## What does this PR do?

Add Vault support for S3 credentials.  

Also keep the environments variable just in case

### Other changes

  - use [ms]() for TTL config
  - move `docker-compose.yml` to repo root
### Boyscout

  - wrap line at 80 column
