### PR TITLE
Add endpoint configuration option that can be used by s3-API compatib…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ S3 has a right system to limit who can upload files to buckets.
 
 These URLs must be generated on the server side, this plugin includes among other things the generation of these URLs so that developers can then send their files directly to S3 from a client application.
 
-## Compatibility matrice
+## Compatibility matrix
 
 | Kuzzle Version | Plugin Version |
 | -------------- | -------------- |
@@ -193,6 +193,8 @@ Deletes an uploaded file from S3.
 You need to set your AWS access key in the environment: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.  
 Your access key must have the following rights: `PutObject` and `DeleteObject`.  
 
+
+
 Then in your `kuzzlerc` file, you can change the following configuration variable:
 
 ```js
@@ -201,8 +203,12 @@ Then in your `kuzzlerc` file, you can change the following configuration variabl
     "s3": {
       // AWS S3 bucket
       "bucketName": "your-s3-bucket",
-      // AWS S3 region
-      "region": "eu-west-3",
+      // AWS S3 compatible service endpoint. It must include the protocol and port.
+      "endpoint": "https://s3.eu-west-3.amazonaws.com",
+      // AWS S3 client Configuration options to parametrice the S3 plugin
+      "s3ClientOptions": {
+        "s3ForcePathStyle": false
+      },      
       // TTL in ms before Presigned URL expire or the uploaded file is deleted
       "signedUrlTTL": 1200000,
       // Redis key prefix
@@ -212,6 +218,12 @@ Then in your `kuzzlerc` file, you can change the following configuration variabl
 }
 ```
 
+In addition to Amazon aws s3, this plugin allows you to use any S3-Api compatible service accesible
+through the [AWS-S3 sdk](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html).
+Any specific [configuration option](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property)
+can be added to the `s3ClientOptions` configuration attribute.
+Please note that the parameters are translated directly,
+so refer to the sdk documentation to available options.
 
 ### AWS S3 Bucket
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Then in your `kuzzlerc` file, you can change the following configuration variabl
       "bucketName": "your-s3-bucket",
       // AWS S3 compatible service endpoint. It must include the protocol and port.
       "endpoint": "https://s3.eu-west-3.amazonaws.com",
-      // AWS S3 client Configuration options to parametrice the S3 plugin
+      // AWS S3 client configuration options.
       "s3ClientOptions": {
         "s3ForcePathStyle": false
       },      

--- a/config/kuzzlerc
+++ b/config/kuzzlerc
@@ -2,7 +2,10 @@
   "plugins": {
     "s3": {
       "bucketName": "your-s3-bucket",
-      "region": "eu-west-3",
+      "endpoint": "https://s3.eu-west-3.amazonaws.com",
+      "s3ClientOptions": {
+        "s3ForcePathStyle": false
+      },
       "signedUrlTTL": "20min",
       "redisPrefix": "s3Plugin/uploads",
       "vault": {

--- a/lib/S3Plugin.js
+++ b/lib/S3Plugin.js
@@ -46,7 +46,7 @@ class S3Plugin {
       bucketName: 'your-s3-bucket',
       endpoint: 'https://s3.eu-west-3.amazonaws.com',
       s3ClientOptions: {
-        's3ForcePathStyle': false
+        s3ForcePathStyle: false
       },
       signedUrlTTL: '20min',
       redisPrefix: 's3Plugin/uploads',

--- a/lib/S3Plugin.js
+++ b/lib/S3Plugin.js
@@ -44,7 +44,10 @@ class S3Plugin {
 
     this.defaultConfig = {
       bucketName: 'your-s3-bucket',
-      region: 'eu-west-3',
+      endpoint: 'https://s3.eu-west-3.amazonaws.com',
+      s3ClientOptions: {
+        's3ForcePathStyle': false
+      },
       signedUrlTTL: '20min',
       redisPrefix: 's3Plugin/uploads',
       vault: {
@@ -99,14 +102,16 @@ class S3Plugin {
   }
 
   init (customConfig, context) {
+
     this.config = { ...this.defaultConfig, ...customConfig };
+    
     if (typeof this.config.signedUrlTTL !== 'number') {
       this.config.signedUrlTTL = ms(this.config.signedUrlTTL);
     }
 
     this.context = context;
-
-    this.baseFileUrl = `https://s3.${this.config.region}.amazonaws.com/${this.config.bucketName}`;
+    
+    this.baseFileUrl = `${this.config.endpoint}/${this.config.bucketName}`;
 
     this._loadS3();
   }
@@ -335,7 +340,8 @@ or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.`;
     } else {
       this.s3 = new AWS.S3({
         signatureVersion: 'v4',
-        region: this.config.region,
+        endpoint: this.config.endpoint,
+        ...this.config.s3ClientOptions,
         credentials: {
           accessKeyId: accessKeyId,
           secretAccessKey: secretAccessKey


### PR DESCRIPTION
## What does this PR do?
Enable to use endpoints configuration variables instead of a fixed region so any S3 compatible service that uses it (like minio) can be used as direct reemplacement of amazon S3. This allows to add a selfhosting files capabilities.

## How should this be manually tested?
Configure the plugin to use endpoint: https://yourminion.example.com:port.

