### PR TITLE
feat(s3/file): support prefix filtering in getFilesKeys action

### DIFF
--- a/doc/3/controllers/file/getFilesKeys/index.md
+++ b/doc/3/controllers/file/getFilesKeys/index.md
@@ -6,7 +6,7 @@ title: getFilesKeys
 
 # getFilesKeys
 
-List the files keys uploaded to an S3 Bucket. Can be filtered on directories using filter.
+List the files keys uploaded to an S3 Bucket. Can be filtered on directories using prefix.
 
 ---
 

--- a/doc/3/controllers/file/getFilesKeys/index.md
+++ b/doc/3/controllers/file/getFilesKeys/index.md
@@ -6,7 +6,7 @@ title: getFilesKeys
 
 # getFilesKeys
 
-List the files keys uploaded to an S3 Bucket.
+List the files keys uploaded to an S3 Bucket. Can be filtered on directories using filter.
 
 ---
 
@@ -15,7 +15,7 @@ List the files keys uploaded to an S3 Bucket.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/file/list-keys/<bucketRegion>/<bucketName>
+URL: http://kuzzle:7512/file/list-keys/<bucketRegion>/<bucketName>?prefix=<optional prefix>
 Method: GET
 ```
 
@@ -25,8 +25,9 @@ Method: GET
 {
   "controller": "s3/file",
   "action": "getFilesKeys",
-  "bucketName": "bucket-name"
-  "bucketRegion": "bucket-region"
+  "bucketName": "bucket-name",
+  "bucketRegion": "bucket-region",
+  "prefix": "optional/path/prefix/"
 }
 ```
 

--- a/lib/controllers/FileController.js
+++ b/lib/controllers/FileController.js
@@ -10,9 +10,10 @@ class FileController extends BaseController {
   async getFilesKeys(request) {
     const bucketName = this.stringArg(request, 'bucketName');
     const region = this.stringArg(request, 'bucketRegion');
+    const prefix = request.input.args?.prefix;
     const s3 = this.getS3Client(region);
 
-    const files = await listAllObjects(s3, { Bucket: bucketName });
+    const files = await listAllObjects(s3, { Bucket: bucketName, ...(prefix && { Prefix: prefix }) });
     return {
       files: files.map((file) => ({
         Key: file.Key,


### PR DESCRIPTION
getFilesKeys now uses aws S3 sdk to filter result based on a prefix

see [AWS doc](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/ListObjectsV2Command/)